### PR TITLE
Add Work/Education and Tagline info to Profile page

### DIFF
--- a/src/page/Profile.svelte
+++ b/src/page/Profile.svelte
@@ -98,33 +98,10 @@
 			</div>
 			<div class="p-2">
 				<h3 class="text-center text-xl text-gray-900 font-medium leading-8">Joh Doe</h3>
-				<div class="text-center text-gray-400 text-xs font-semibold">
-					<p>Web Developer</p>
+				<div class="text-center text-gray-500 text-xs">
+					<p>Google Inc.</p>
+					<p><i>Work hard, play nice :)</i></p>
 				</div>
-				<table class="text-xs my-3">
-					<tbody
-						><tr>
-							<td class="px-2 py-2 text-gray-500 font-semibold">Address</td>
-							<td class="px-2 py-2">Chatakpur-3, Dhangadhi Kailali</td>
-						</tr>
-						<tr>
-							<td class="px-2 py-2 text-gray-500 font-semibold">Phone</td>
-							<td class="px-2 py-2">+977 9955221114</td>
-						</tr>
-						<tr>
-							<td class="px-2 py-2 text-gray-500 font-semibold">Email</td>
-							<td class="px-2 py-2">john@exmaple.com</td>
-						</tr>
-						<tr>
-							<td class="px-2 py-2 text-gray-500 font-semibold">Work/Education</td>
-							<td class="px-2 py-2">Google Inc.</td>
-						</tr>
-						<tr>
-							<td class="px-2 py-2 text-gray-500 font-semibold">Tagline</td>
-							<td class="px-2 py-2">Work hard, play nice :)</td>
-						</tr>
-					</tbody>
-				</table>
 
 				<div class="text-center my-3">
 					<a class="text-xs text-indigo-500 italic hover:underline hover:text-indigo-600 font-medium" href="#"

--- a/src/page/Profile.svelte
+++ b/src/page/Profile.svelte
@@ -115,6 +115,14 @@
 							<td class="px-2 py-2 text-gray-500 font-semibold">Email</td>
 							<td class="px-2 py-2">john@exmaple.com</td>
 						</tr>
+						<tr>
+							<td class="px-2 py-2 text-gray-500 font-semibold">Work/Education</td>
+							<td class="px-2 py-2">Google Inc.</td>
+						</tr>
+						<tr>
+							<td class="px-2 py-2 text-gray-500 font-semibold">Tagline</td>
+							<td class="px-2 py-2">Work hard, play nice :)</td>
+						</tr>
 					</tbody>
 				</table>
 


### PR DESCRIPTION
Not sure if it's enough with this...

![image](https://user-images.githubusercontent.com/1944438/135927896-9dd55e1b-ed0c-473c-b1ce-fcf82b937607.png)

Need @Ananto30 to see if this is correct.

Solves #3 